### PR TITLE
Fix color cycling

### DIFF
--- a/emmaemb/core.py
+++ b/emmaemb/core.py
@@ -139,8 +139,6 @@ class Emma:
 
     def _assign_colour_to_embedding_space(self, num_emb_spaces: int) -> str:
         """Assign a colour to the embedding space."""
-        if num_emb_spaces > len(EMB_SPACE_COLORS):
-            return EMB_SPACE_COLORS[num_emb_spaces]
         # If there are more embedding spaces than predefined colors,
         # cycle through the list
         return EMB_SPACE_COLORS[


### PR DESCRIPTION
Hello! When adding more embedding spaces than `EMB_SPACE_COLORS` are defined in `config.py`, `Emma._assign_colour_to_embedding_space` in `core.py` currently crashes because of a `>` that probably wants to be a `<`. Since the cycling through colors is implemented below anyways, we can just remove the condition altogether and fix the issue :)