### PR TITLE
Verbose hover tooltips

### DIFF
--- a/emmaemb/vizualization.py
+++ b/emmaemb/vizualization.py
@@ -107,7 +107,7 @@ def plot_emb_space(
         "x": embeddings_2d[:, 0],
         "y": embeddings_2d[:, 1],
         "title": f"{emb_space} embeddings after {method}",
-        "hover_data": {"Sample": emma.sample_names},
+        "hover_data": emma.metadata.to_dict(orient='list'),
         "opacity": 0.5,
     }
 

--- a/emmaemb/vizualization.py
+++ b/emmaemb/vizualization.py
@@ -43,6 +43,7 @@ def plot_emb_space(
     normalise: bool = True,
     color_by: str = None,
     logarithmic_colors: bool = False,
+    verbose_tooltips: bool = False,
     random_state: int = 42,
     perplexity: int = 30,
     shuffle_umap: bool = True,
@@ -60,6 +61,8 @@ def plot_emb_space(
             prior to dimensionality reduction. Defaults to True.
         color_by (str, optional): A column name from the metadata stored in \
             the Emma object, by which the dots are coloured. Defaults to None.
+        verbose_tooltips (bool, optional): Show all metadata on hover tooltips \
+            rather than only the sample ID. Defaults to False.
         logarithmic_colors (bool, optional): Use a logarithmic scale to color by
             a numerical column. Defaults to False.
         random_state (int, optional): Random state for UMAP or TSNE. Defaults \
@@ -102,12 +105,16 @@ def plot_emb_space(
     else:
         raise ValueError(f"Method {method} not implemented")
 
+    if verbose_tooltips:
+        hover_data = emma.metadata.to_dict(orient='list')
+    else:
+        hover_data = {"Sample": emma.sample_names}
     # args for px.scatter
     scatter_args = {
         "x": embeddings_2d[:, 0],
         "y": embeddings_2d[:, 1],
         "title": f"{emb_space} embeddings after {method}",
-        "hover_data": emma.metadata.to_dict(orient='list'),
+        "hover_data": hover_data,
         "opacity": 0.5,
     }
 


### PR DESCRIPTION
> [!warning]
> Built on top of #3 and #4, those PRs should be merged before this one

This PR makes the hover tooltips on embedding plots more verbose by displaying all available metadata. Example:

<img width="254" alt="image" src="https://github.com/user-attachments/assets/3512eb08-f5ae-49a5-8a84-236383e467fc" />
