### PR TITLE
Enable multiprocessing for pairwise distances

### DIFF
--- a/emmaemb/core.py
+++ b/emmaemb/core.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pandas as pd
 import plotly.express as px
-from scipy.spatial.distance import pdist, squareform
+from sklearn.metrics import pairwise_distances
 from sklearn.preprocessing import StandardScaler
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
@@ -267,7 +267,7 @@ class Emma:
             emb = self.emb[emb_space]["emb"]
             emb_norm = np.linalg.norm(emb, axis=1)
             emb = emb / emb_norm[:, None]  # divide each row by its norm
-            emb_pwd = squareform(pdist(emb, metric="sqeuclidean"))
+            emb_pwd = pairwise_distances(emb, metric="sqeuclidean", n_jobs=-1)
             return emb_pwd
 
         elif metric == "euclidean_normalised":
@@ -276,12 +276,12 @@ class Emma:
             emb = self.emb[emb_space]["emb"]
             emb_norm = np.linalg.norm(emb, axis=1)
             emb = emb / emb_norm[:, None]  # divide each row by its norm
-            emb_pwd = squareform(pdist(emb, metric="euclidean"))
+            emb_pwd = pairwise_distances(emb, metric="euclidean", n_jobs=-1)
             return emb_pwd
 
         elif metric == "cityblock_normalised":
-            emb_pwd = squareform(
-                pdist(self.emb[emb_space]["emb"], metric="cityblock")
+            emb_pwd = pairwise_distances(
+                self.emb[emb_space]["emb"], metric="cityblock", n_jobs=-1
             )
             emb_pwd = emb_pwd / len(self.emb[emb_space]["emb"][1])
             return emb_pwd
@@ -290,10 +290,10 @@ class Emma:
             # substract the mean of each column from each value
             emb = self.emb[emb_space]["emb"]
             emb = emb - np.median(emb, axis=0)  # emb.median(axis=0)
-            emb_pwd = squareform(pdist(emb, metric="cosine"))
+            emb_pwd = pairwise_distances(emb, metric="cosine", n_jobs=-1)
             return emb_pwd
 
-        emb_pwd = squareform(pdist(embeddings, metric=metric))
+        emb_pwd = pairwise_distances(embeddings, metric=metric, n_jobs=-1)
         return emb_pwd
 
     def calculate_pairwise_distances(

--- a/emmaemb/core.py
+++ b/emmaemb/core.py
@@ -10,6 +10,7 @@ from sklearn.manifold import TSNE
 from umap import UMAP
 
 from emmaemb.config import EMB_SPACE_COLORS, DISTANCE_METRIC_ALIASES
+from emmaemb.utils import row_argsort_parallel
 
 
 class Emma:
@@ -319,7 +320,7 @@ class Emma:
             )
 
             # Compute ranks based on distances
-            ranked_indices = np.argsort(emb_pwd, axis=1)
+            ranked_indices = row_argsort_parallel(emb_pwd)
 
             if "pairwise_distances" not in self.emb[emb_space]:
                 self.emb[emb_space]["pairwise_distances"] = {}

--- a/emmaemb/utils.py
+++ b/emmaemb/utils.py
@@ -1,0 +1,10 @@
+import numba as nb
+import numpy as np
+
+# parallelized version of `np.argsort(matrix, axis=1)`
+@nb.njit(parallel=True)
+def row_argsort_parallel(a):
+    b = np.empty(a.shape, dtype=np.int32)
+    for i in nb.prange(a.shape[0]):
+        b[i, :] = np.argsort(a[i, :])
+    return b


### PR DESCRIPTION
Computing pairwise distances scales quadratically and SciPy's implementation doesn't do multiprocessing. This PR swaps it out for the scikit-learn implementation which does, allowing significant speed-ups when lots of CPUs are available.

After having adjusted this, the bottleneck was computing ranks with `np.argsort` so I wrote a parallelized version of that as well and replaced `argsort` with it which makes it slightly slower on a single CPU but a lot faster with more CPUs. I added the parallel `argsort` replacement to a new `utils.py` file, feel free to suggest a better place. It can't go into `functions.py` because that would create a circular import with `core.py`.

Note that there is a conflict with #5 in the import statement so whichever of the two PRs we merge second has to be adjusted, I'll do that once the first of the two is merged :)