### PR TITLE
More categorical colors

### DIFF
--- a/emmaemb/core.py
+++ b/emmaemb/core.py
@@ -1,4 +1,5 @@
 import os
+import math
 
 import numpy as np
 import pandas as pd
@@ -119,11 +120,9 @@ class Emma:
 
             colors = (
                 px.colors.qualitative.Set2
-                + px.colors.qualitative.Set2
-                * (len(column_values) - len(px.colors.qualitative.Set2))
-            )
+                * math.ceil(len(column_values) / len(px.colors.qualitative.Set2))
+            )[:len(column_values)]
 
-            colors = colors[: len(column_values)]  # shorten if necessary
             color_map[column] = dict(zip(column_values, colors))
 
             # check for specifial values

--- a/emmaemb/core.py
+++ b/emmaemb/core.py
@@ -118,9 +118,20 @@ class Emma:
                 )
                 continue
 
+            # select smallest color set from list that fits or fall back to 24 colors
+            color_set = next((
+                set for set in [
+                    px.colors.qualitative.Set2, # 8 colors
+                    px.colors.qualitative.Pastel, # 11 colors
+                    px.colors.qualitative.Set3, # 12 colors
+                    px.colors.qualitative.Light24, # 24 colors
+                ]
+                if len(set) >= len(column_values)
+            ), px.colors.qualitative.Alphabet)
+
+            # repeat colors if we don't have enough
             colors = (
-                px.colors.qualitative.Set2
-                * math.ceil(len(column_values) / len(px.colors.qualitative.Set2))
+                color_set * math.ceil(len(column_values) / len(color_set))
             )[:len(column_values)]
 
             color_map[column] = dict(zip(column_values, colors))


### PR DESCRIPTION
Currently we always use a color set with only 8 colors for categorical values but support up to 50 distinct values which makes it easy for colors to repeat. This PR implements falling back to bigger color sets if the original is not big enough (first to "Pastel", then "Set3", then "Light24" and finally "Alphabet", selected for size and similarity to original color set)

<img width="835" alt="image" src="https://github.com/user-attachments/assets/e4cc7dc4-8484-47b7-b4a5-e547f886e72a" />
